### PR TITLE
If radio-button-group is disabled also all added items should be disabled

### DIFF
--- a/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -48,7 +48,7 @@ public class RadioButtonGroup<T>
 
     private DataProvider<T, ?> dataProvider = DataProvider.ofItems();
 
-    private SerializablePredicate<T> itemEnabledProvider = item -> true;
+    private SerializablePredicate<T> itemEnabledProvider = item -> isEnabled();
 
     private ComponentRenderer<? extends Component, T> itemRenderer = new TextRenderer<>();
 
@@ -122,7 +122,7 @@ public class RadioButtonGroup<T>
      * Returns the item component renderer.
      *
      * @return the item renderer
-     * @see #setItemRenderer
+     * @see #setRenderer(ComponentRenderer)
      */
     public ComponentRenderer<? extends Component, T> getItemRenderer() {
         return itemRenderer;
@@ -149,6 +149,7 @@ public class RadioButtonGroup<T>
      */
     public void setEnabled(boolean enabled) {
         setDisabled(!enabled);
+        refreshButtons();
     }
 
     /**

--- a/src/test/java/com/vaadin/flow/component/radiobutton/demo/DisabledItemsPage.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/demo/DisabledItemsPage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.demo;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@Route("disabled-items")
+@Theme(Lumo.class)
+public class DisabledItemsPage extends Div {
+
+    public DisabledItemsPage() {
+        RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup();
+        radioButtonGroup.setId("button-group");
+        radioButtonGroup.setEnabled(false);
+
+        NativeButton nativeButton = new NativeButton("add",
+                event -> radioButtonGroup.setItems("one", "two"));
+        nativeButton.setId("add-button");
+
+        add(radioButtonGroup, nativeButton);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsIT.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsIT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.tests;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.demo.ComponentDemoTest;
+
+public class DisabledItemsIT extends ComponentDemoTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/disabled-items";
+    }
+
+    @Test
+    public void set_items_to_disabled_group_should_be_disabled() {
+        WebElement group = layout.findElement(By.id("button-group"));
+
+        List<WebElement> buttons = group
+                .findElements(By.tagName("vaadin-radio-button"));
+        Assert.assertTrue("No buttons should be present", buttons.isEmpty());
+
+        // Click button to add items
+        layout.findElement(By.id("add-button")).click();
+
+
+        buttons = group.findElements(By.tagName("vaadin-radio-button"));
+        Assert.assertEquals("Group should have buttons", 2, buttons.size());
+
+        // re-get the elements to not get stale element exception.
+        for (WebElement button : group.findElements(By.tagName("vaadin-radio-button"))) {
+            Assert.assertEquals("All buttons should be disabled",
+                    Boolean.TRUE.toString(), button.getAttribute("disabled"));
+        }
+    }
+}


### PR DESCRIPTION
The default itemEnabledProvider should be based on
the enabled state of the group.

Fixes vaadin/flow#3767

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button-flow/39)
<!-- Reviewable:end -->
