### PR TITLE
Correct the extends for DisabledItemsPage

### DIFF
--- a/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPage.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPage.java
@@ -13,20 +13,22 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.radiobutton.demo;
+package com.vaadin.flow.component.radiobutton.tests;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.Theme;
-import com.vaadin.flow.theme.lumo.Lumo;
 
 @Route("disabled-items")
-@Theme(Lumo.class)
-public class DisabledItemsPage extends Div {
+public class DisabledItemsPage extends DemoView {
 
-    public DisabledItemsPage() {
+    @Override
+    protected void initView() {
+        DisabledItemsPage();
+    }
+
+    public void DisabledItemsPage() {
         RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup();
         radioButtonGroup.setId("button-group");
         radioButtonGroup.setEnabled(false);

--- a/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPageIT.java
@@ -24,7 +24,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.demo.ComponentDemoTest;
 
-public class DisabledItemsIT extends ComponentDemoTest {
+public class DisabledItemsPageIT extends ComponentDemoTest {
 
     @Override
     protected String getTestPath() {
@@ -42,7 +42,7 @@ public class DisabledItemsIT extends ComponentDemoTest {
         // Click button to add items
         layout.findElement(By.id("add-button")).click();
 
-
+        waitForElementPresent(By.tagName("vaadin-radio-button"));
         buttons = group.findElements(By.tagName("vaadin-radio-button"));
         Assert.assertEquals("Group should have buttons", 2, buttons.size());
 


### PR DESCRIPTION
Based on the test demo, it should use DemoView instead of div, otherwise
the IT test class cannot locate the element.

Move DisabledItemsPage to tests package, as demo package will be
deployed separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button-flow/40)
<!-- Reviewable:end -->
