### PR TITLE
Use disabled property to mark radio button group as read-only

### DIFF
--- a/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -52,6 +52,8 @@ public class RadioButtonGroup<T>
 
     private ComponentRenderer<? extends Component, T> itemRenderer = new TextRenderer<>();
 
+    private boolean isReadOnly;
+
     public RadioButtonGroup() {
         getElement().synchronizeProperty(VALUE, "value-changed");
     }
@@ -143,8 +145,25 @@ public class RadioButtonGroup<T>
 
     @Override
     public void onEnabledStateChanged(boolean enabled) {
-        setDisabled(!enabled);
+        if (isReadOnly()) {
+            setDisabled(true);
+        } else {
+            setDisabled(!enabled);
+        }
         refreshButtons();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) {
+        isReadOnly = readOnly;
+        if (isEnabled()) {
+            setDisabled(readOnly);
+        }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return isReadOnly;
     }
 
     private void refresh() {

--- a/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RadioButtonGroupTest {
+
+    @Test
+    public void setReadOnlyRadioGroup_groupIsReadOnlyAndDisabled() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setReadOnly(true);
+        Assert.assertTrue(group.isReadOnly());
+
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                group.getElement().getProperty("disabled"));
+    }
+
+    @Test
+    public void setReadOnlyDisabledRadioGroup_groupIsDisabledAndReadonly() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setEnabled(false);
+        group.setReadOnly(true);
+
+        Assert.assertTrue(group.isReadOnly());
+        Assert.assertFalse(group.isEnabled());
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                group.getElement().getProperty("disabled"));
+    }
+
+    @Test
+    public void unsetReadOnlyDisabledRadioGroup_groupIsDisabledAndNotReadonly() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setEnabled(false);
+        group.setReadOnly(false);
+
+        Assert.assertFalse(group.isReadOnly());
+        Assert.assertFalse(group.isEnabled());
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                group.getElement().getProperty("disabled"));
+    }
+
+    @Test
+    public void setReadOnlyEnabledRadioGroup_groupIsDisabledAndNotReadonly() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setReadOnly(true);
+        group.setEnabled(true);
+
+        Assert.assertTrue(group.isReadOnly());
+        Assert.assertTrue(group.isEnabled());
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                group.getElement().getProperty("disabled"));
+
+        group.setReadOnly(false);
+
+        Assert.assertTrue(group.isEnabled());
+        Assert.assertEquals(Boolean.FALSE.toString(),
+                group.getElement().getProperty("disabled"));
+    }
+
+    @Test
+    public void unsetReadOnlyEnabledRadioGroup_groupIsEnabled() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setEnabled(false);
+        group.setReadOnly(true);
+        group.setEnabled(true);
+
+        group.setReadOnly(false);
+
+        Assert.assertTrue(group.isEnabled());
+        Assert.assertEquals(Boolean.FALSE.toString(),
+                group.getElement().getProperty("disabled"));
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/radiobutton/demo/RadioButtonGroupView.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/demo/RadioButtonGroupView.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.IconRenderer;
@@ -63,6 +64,7 @@ public class RadioButtonGroupView extends DemoView {
         addDisabled();
         addDisabledItems();
         addComponentAfterItems();
+        addReadOnlyGroup();
         insertComponentsBetweenItems();
         prependAndInsertComponents();
         dynamicComponents();
@@ -161,6 +163,28 @@ public class RadioButtonGroupView extends DemoView {
         group.setId("button-group-disabled");
 
         addCard("Disabled radio button group", group);
+    }
+
+    private void addReadOnlyGroup() {
+        // begin-source-example
+        // source-example-heading: Read-only radio button group
+        Div valueInfo = new Div();
+
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setItems("foo", "bar", "baz");
+        group.setReadOnly(true);
+
+        NativeButton button = new NativeButton("Switch read-only state",
+                event -> group.setReadOnly(!group.isReadOnly()));
+        group.addValueChangeListener(
+                event -> valueInfo.setText(group.getValue()));
+        // end-source-example
+
+        group.setId("button-group-read-only");
+        valueInfo.setId("selected-value-info");
+        button.setId("switch-read-only");
+
+        addCard("Read-only radio button group", group, button, valueInfo);
     }
 
     private void addDisabledItems() {

--- a/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
@@ -136,6 +136,9 @@ public class RadioButtonGroupIT extends ComponentDemoTest {
         Assert.assertEquals(Boolean.TRUE.toString(),
                 group.getAttribute("disabled"));
 
+        scrollToElement(group);
+        getCommandExecutor().executeScript("window.scrollBy(0,50);");
+
         new Actions(getDriver()).moveToElement(buttons.get(1)).click().build()
                 .perform();
 
@@ -144,16 +147,21 @@ public class RadioButtonGroupIT extends ComponentDemoTest {
 
         // make the group not read-only
         WebElement switchReadOnly = findElement(By.id("switch-read-only"));
-        scrollIntoViewAndClick(switchReadOnly);
+        new Actions(getDriver()).moveToElement(switchReadOnly).click().build()
+                .perform();
 
-        scrollIntoViewAndClick(buttons.get(1));
+        new Actions(getDriver()).moveToElement(buttons.get(1)).click().build()
+                .perform();
         Assert.assertEquals("bar", valueInfo.getText());
 
         // make it read-only again
-        scrollIntoViewAndClick(switchReadOnly);
+        new Actions(getDriver()).moveToElement(switchReadOnly).click().build()
+                .perform();
 
         // click to the first item
-        scrollIntoViewAndClick(buttons.get(0));
+        new Actions(getDriver()).moveToElement(buttons.get(0)).click().build()
+                .perform();
+
         // Nothing has changed
         Assert.assertEquals("bar", valueInfo.getText());
     }

--- a/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.demo.ComponentDemoTest;
 
@@ -121,6 +122,40 @@ public class RadioButtonGroupIT extends ComponentDemoTest {
 
         Assert.assertEquals(Boolean.TRUE.toString(),
                 buttons.get(1).getAttribute("disabled"));
+    }
+
+    @Test
+    public void readOnlyGroup() {
+        WebElement group = layout.findElement(By.id("button-group-read-only"));
+
+        List<WebElement> buttons = group
+                .findElements(By.tagName("vaadin-radio-button"));
+
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                buttons.get(1).getAttribute("disabled"));
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                group.getAttribute("disabled"));
+
+        new Actions(getDriver()).moveToElement(buttons.get(1)).click().build()
+                .perform();
+
+        WebElement valueInfo = layout.findElement(By.id("selected-value-info"));
+        Assert.assertEquals("", valueInfo.getText());
+
+        // make the group not read-only
+        WebElement switchReadOnly = findElement(By.id("switch-read-only"));
+        scrollIntoViewAndClick(switchReadOnly);
+
+        scrollIntoViewAndClick(buttons.get(1));
+        Assert.assertEquals("bar", valueInfo.getText());
+
+        // make it read-only again
+        scrollIntoViewAndClick(switchReadOnly);
+
+        // click to the first item
+        scrollIntoViewAndClick(buttons.get(0));
+        // Nothing has changed
+        Assert.assertEquals("bar", valueInfo.getText());
     }
 
     @Test


### PR DESCRIPTION
Fixes #3891

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button-flow/46)
<!-- Reviewable:end -->
