### PR TITLE
Fix wrong selection on reset

### DIFF
--- a/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.radiobutton;
 
-import java.util.Objects;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.data.binder.HasDataProvider;
 import com.vaadin.flow.data.binder.HasItemsAndComponents;
@@ -28,8 +26,14 @@ import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.selection.SingleSelect;
 import com.vaadin.flow.function.SerializablePredicate;
 
+import java.util.Objects;
+
 /**
- * Server-side component for the {@code vaadin-radio-group} element.
+ * A single select component using radio buttons as options.
+ * <p>
+ * This is a server side Java integration for the {@code vaadin-radio-group} element.
+ * <p>
+ * Usage examples, see <a href="https://vaadin.com/components/vaadin-radio-button/java-examples">the demo in vaadin.com</a>.
  *
  * @author Vaadin Ltd.
  */
@@ -78,7 +82,7 @@ public class RadioButtonGroup<T>
     @Override
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider = dataProvider;
-        refresh();
+        reset();
     }
 
     /**
@@ -163,9 +167,10 @@ public class RadioButtonGroup<T>
         return isReadOnly;
     }
 
-    private void refresh() {
+    private void reset() {
         keyMapper.removeAll();
         removeAll();
+        clear();
         getDataProvider().fetch(new Query<>()).map(this::createRadioButton)
                 .forEach(this::add);
     }

--- a/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -15,16 +15,16 @@
  */
 package com.vaadin.flow.component.radiobutton;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 public class RadioButtonGroupTest {
 
@@ -128,4 +128,23 @@ public class RadioButtonGroupTest {
         Assert.assertEquals("enabled", event.getValue());
     }
 
+    @Test
+    public void changeItems_selectionIsReset() {
+        RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup<>();
+        radioButtonGroup.setItems("Foo","Bar");
+
+        AtomicReference<String> capture = new AtomicReference<>();
+        radioButtonGroup.addValueChangeListener(event -> capture.set(event.getValue()));
+
+        radioButtonGroup.setValue("Foo");
+
+        Assert.assertEquals("Foo", capture.get());
+
+        Assert.assertEquals("Foo", radioButtonGroup.getValue());
+
+        radioButtonGroup.setItems("Foo", "Baz");
+
+        Assert.assertEquals(null, radioButtonGroup.getValue());
+        Assert.assertEquals(null, capture.get());
+    }
 }


### PR DESCRIPTION
Selected value should be cleared after items have been reset.
Also added a bit more helpful javadocs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button-flow/53)
<!-- Reviewable:end -->
