### PR TITLE
#82 RadioButtonGroup should use DataRefreshEvent for item refresh

### DIFF
--- a/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.data.binder.HasDataProvider;
 import com.vaadin.flow.data.binder.HasItemsAndComponents;
+import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.KeyMapper;
 import com.vaadin.flow.data.provider.Query;
@@ -103,8 +104,16 @@ public class RadioButtonGroup<T>
         if (dataProviderListenerRegistration != null) {
             dataProviderListenerRegistration.remove();
         }
+
         dataProviderListenerRegistration = dataProvider
-                .addDataProviderListener(event -> reset());
+                .addDataProviderListener(event -> {
+                    if (event instanceof DataChangeEvent.DataRefreshEvent) {
+                        resetRadioButton(
+                            ((DataChangeEvent.DataRefreshEvent<T>) event).getItem());
+                    } else {
+                        reset();
+                    }
+                });
     }
 
     /**
@@ -260,6 +269,13 @@ public class RadioButtonGroup<T>
         clear();
         getDataProvider().fetch(new Query<>()).map(this::createRadioButton)
                 .forEach(this::add);
+    }
+
+    private void resetRadioButton(T item) {
+        getRadioButtons().filter(radioButton ->
+            getDataProvider().getId(radioButton.getItem()).equals(getDataProvider().getId(item)))
+        .findFirst()
+        .ifPresent(this::updateButton);
     }
 
     private Component createRadioButton(T item) {

--- a/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/ItemHelper.java
+++ b/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/ItemHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton;
+
+public class ItemHelper {
+    private String name;
+    private String code;
+
+    public ItemHelper(String name, String code) {
+        this.name = name;
+        this.code = code;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return code.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == null) {
+            return false;
+        }
+        ItemHelper other = (ItemHelper) obj;
+        if (code == null && other.code != null) {
+            return false;
+        } else if (!code.equals(other.code)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}

--- a/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 public class RadioButtonGroupTest {
 
+    private static final String OUTER_HTML = "<vaadin-radio-button>\n <span>%s</span>\n</vaadin-radio-button>";
+
     @Test
     public void setReadOnlyRadioGroup_groupIsReadOnlyAndDisabled() {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
@@ -146,5 +148,47 @@ public class RadioButtonGroupTest {
 
         Assert.assertEquals(null, radioButtonGroup.getValue());
         Assert.assertEquals(null, capture.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResetAllItems() {
+        RadioButtonGroup<ItemHelper> group = new RadioButtonGroup<ItemHelper>();
+        ItemHelper item1 = new ItemHelper("foo", "01");
+        ItemHelper item2 = new ItemHelper("baz", "02");
+
+        group.setItems(item1, item2);
+
+        item1.setName("zoo");
+        item2.setName("bar");
+        group.getDataProvider().refreshAll();
+
+        List<Component> components = group.getChildren().collect(Collectors.toList());
+        RadioButton<ItemHelper> radioZoo = (RadioButton<ItemHelper>) components.get(0);
+        RadioButton<ItemHelper> radioBar = (RadioButton<ItemHelper>) components.get(1);
+
+        Assert.assertEquals(String.format(OUTER_HTML, "zoo"), radioZoo.getElement().getOuterHTML());
+        Assert.assertEquals(String.format(OUTER_HTML, "bar"), radioBar.getElement().getOuterHTML());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResetSingleItem() {
+        RadioButtonGroup<ItemHelper> group = new RadioButtonGroup<ItemHelper>();
+        ItemHelper item1 = new ItemHelper("foo", "01");
+        ItemHelper item2 = new ItemHelper("baz", "02");
+
+        group.setItems(item1, item2);
+
+        item1.setName("zoo");
+        item2.setName("bar");
+        group.getDataProvider().refreshItem(item2);
+
+        List<Component> components = group.getChildren().collect(Collectors.toList());
+        RadioButton<ItemHelper> radioFoo = (RadioButton<ItemHelper>) components.get(0);
+        RadioButton<ItemHelper> radioBar = (RadioButton<ItemHelper>) components.get(1);
+
+        Assert.assertEquals(String.format(OUTER_HTML, "foo"), radioFoo.getElement().getOuterHTML());
+        Assert.assertEquals(String.format(OUTER_HTML, "bar"), radioBar.getElement().getOuterHTML());
     }
 }


### PR DESCRIPTION
Applied changes to refresh an item when a DataRefreshEvent is invoked.
Added unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button-flow/84)
<!-- Reviewable:end -->
