### PR TITLE
Fix removing previous not radio-button component

### DIFF
--- a/vaadin-radio-button-flow-demo/src/main/java/com/vaadin/flow/component/radiobutton/demo/RadioButtonGroupView.java
+++ b/vaadin-radio-button-flow-demo/src/main/java/com/vaadin/flow/component/radiobutton/demo/RadioButtonGroupView.java
@@ -308,6 +308,8 @@ public class RadioButtonGroupView extends DemoView {
         addCard("Insert components before item in group", group);
     }
 
+    private Label below;
+
     private void dynamicComponents() {
         // begin-source-example
         // source-example-heading: Move component in group on selection
@@ -315,12 +317,12 @@ public class RadioButtonGroupView extends DemoView {
 
         group.setItems("foo", "foo-bar", "bar", "bar-foo", "baz", "baz-baz");
 
-        Label below = new Label("= After Selected =");
-
         group.addValueChangeListener(event -> {
-            if (below.getParent().isPresent()) {
+            if (below != null && below.getParent().isPresent()) {
                 group.remove(below);
             }
+            below = new Label("= After Selected =");
+
             group.addComponents(event.getValue(), below);
         });
 


### PR DESCRIPTION
In case if we have selected radio-button and selecting next radion-button in "Move component in group on selection" test it's throwing exception "Could not locate the item after which to insert components."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button-flow/100)
<!-- Reviewable:end -->
