### PR TITLE
Replace Id use with attribute

### DIFF
--- a/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
+++ b/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
@@ -326,7 +326,7 @@ public class RadioButtonGroupIT extends ComponentDemoTest {
                 group.getAttribute("label"), "Group label");
 
         TestBenchElement errorMessage = group.$(TestBenchElement.class)
-                .id("vaadin-radio-group-error-1");
+                .attribute("part", "error-message").first();
         verifyGroupValid(group, errorMessage);
 
         layout.findElement(By.id("group-with-label-button")).click();


### PR DESCRIPTION
The id search is not reliable for the error message when testing with flow 2.2-snapshot
fix snapshot validation build. 