### PR TITLE
Use HasItemComponents.ItemComponent

### DIFF
--- a/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButton.java
+++ b/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButton.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.component.radiobutton;
 
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.data.binder.HasItemsAndComponents.ItemComponent;
+import com.vaadin.flow.data.binder.HasItemComponents.ItemComponent;
 
 /**
  * Server-side component for the {@code vaadin-radio-button} element.


### PR DESCRIPTION
Update to latest change done in https://github.com/vaadin/flow/pull/8706
HasItems in the HasItemsAndComponents does not allow some components (at least CheckboxGroup and Select) to support HasXXXDataView interfaces because of API methods name clashing. A new HasItemComponents has been introduced to be used in components instead.