### PR TITLE
fix: prevent possible memory leak

### DIFF
--- a/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -108,7 +108,7 @@ public class RadioButtonGroup<T>
         setupDataProviderListener(dataProvider);
     }
 
-    private void setupDataProviderListener(DataProvider<ITEM, ?> dataProvider) {
+    private void setupDataProviderListener(DataProvider<T, ?> dataProvider) {
         if (dataProviderListenerRegistration != null) {
             dataProviderListenerRegistration.remove();
         }

--- a/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -20,7 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.data.binder.HasDataProvider;
@@ -103,10 +105,13 @@ public class RadioButtonGroup<T>
         this.dataProvider = dataProvider;
         reset();
 
+        setupDataProviderListener(dataProvider);
+    }
+
+    private void setupDataProviderListener(DataProvider<ITEM, ?> dataProvider) {
         if (dataProviderListenerRegistration != null) {
             dataProviderListenerRegistration.remove();
         }
-
         dataProviderListenerRegistration = dataProvider
                 .addDataProviderListener(event -> {
                     if (event instanceof DataChangeEvent.DataRefreshEvent) {
@@ -116,6 +121,23 @@ public class RadioButtonGroup<T>
                         reset();
                     }
                 });
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        if (getDataProvider() != null && dataProviderListenerRegistration == null) {
+            setupDataProviderListener(getDataProvider());
+        }
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        if (dataProviderListenerRegistration != null) {
+        	dataProviderListenerRegistration.remove();
+        	dataProviderListenerRegistration = null;
+        }
+        super.onDetach(detachEvent);
     }
 
     /**


### PR DESCRIPTION
Before this patch dataProviderListenerRegistration was correctly removed before setting new one, but possible issues regarding component remove/re-add to layout etc. was not handled.